### PR TITLE
M_KII_LOG was removed. M_KII_DEBUG was added.

### DIFF
--- a/KiiThingSDK.xcodeproj/project.pbxproj
+++ b/KiiThingSDK.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		B613F69319F50D6100AC5548 /* kii_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = B613F69119F50D6100AC5548 /* kii_utils.c */; };
 		B613F69419F50D7600AC5548 /* kii_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = B613F69119F50D6100AC5548 /* kii_utils.c */; };
 		B69FA67119F6415700DC1872 /* URLBuilderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B69FA67019F6415700DC1872 /* URLBuilderTest.m */; };
+		B69FA67319F8A83300DC1872 /* kii_logger.c in Sources */ = {isa = PBXBuildFile; fileRef = B69FA67219F8A83300DC1872 /* kii_logger.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,6 +144,7 @@
 		B613F69119F50D6100AC5548 /* kii_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kii_utils.c; sourceTree = "<group>"; };
 		B613F69219F50D6100AC5548 /* kii_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kii_utils.h; sourceTree = "<group>"; };
 		B69FA67019F6415700DC1872 /* URLBuilderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = URLBuilderTest.m; sourceTree = "<group>"; };
+		B69FA67219F8A83300DC1872 /* kii_logger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kii_logger.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 				7485E61A19E5360000BCA19C /* kii_cloud.c */,
 				B613F69119F50D6100AC5548 /* kii_utils.c */,
 				B613F69219F50D6100AC5548 /* kii_utils.h */,
+				B69FA67219F8A83300DC1872 /* kii_logger.c */,
 			);
 			path = KiiThingSDK;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 				B613F69319F50D6100AC5548 /* kii_utils.c in Sources */,
 				7416A5AC19E3C42A007DCC45 /* error.c in Sources */,
 				747F3D5819F4D3A800C1372A /* kii_libc.c in Sources */,
+				B69FA67319F8A83300DC1872 /* kii_logger.c in Sources */,
 				7416A5B019E3C42A007DCC45 /* hashtable_seed.c in Sources */,
 				7416A5AA19E3C42A007DCC45 /* dump.c in Sources */,
 				7416A5BE19E3C42A007DCC45 /* value.c in Sources */,

--- a/KiiThingSDK/kii_cloud.c
+++ b/KiiThingSDK/kii_cloud.c
@@ -289,7 +289,7 @@ kii_error_code_t kii_register_thing(kii_app_t app,
     if ((200 <= respCode) && (respCode < 300)) {
         json_error_t jErr;
         json_t* respJson = NULL;
-        M_KII_LOG("response: %s", respData);
+        M_KII_DEBUG(prv_log("response: %s", respData));
         respJson = json_loads(respData, 0, &jErr);
         if (respJson != NULL) {
             json_t* accessTokenJson = json_object_get(respJson, "_accessToken");
@@ -310,7 +310,7 @@ kii_error_code_t kii_register_thing(kii_app_t app,
     } else {
         json_error_t jErr;
         json_t* errJson = NULL;
-        M_KII_LOG("response: %s", respData);
+        M_KII_DEBUG(prv_log("response: %s", respData));
         err->status_code = (int)respCode;
         err->error_code = kii_strdup("");
         errJson = json_loads(respData, 0, &jErr);

--- a/KiiThingSDK/kii_logger.c
+++ b/KiiThingSDK/kii_logger.c
@@ -1,0 +1,21 @@
+/*
+  kii_logger.c
+  KiiThingSDK
+
+  Copyright (c) 2014 Kii. All rights reserved.
+*/
+
+#include "kii_logger.h"
+
+#include <stdarg.h>
+
+int prv_log(const char* format, ...)
+{
+    int retval = 0;
+    va_list list;
+    va_start(list, format);
+    retval = vprintf(format, list);
+    printf("\n");
+    va_end(list);
+    return retval;
+}

--- a/KiiThingSDK/kii_logger.h
+++ b/KiiThingSDK/kii_logger.h
@@ -16,13 +16,15 @@ extern "C" {
 #endif
 
 #ifdef DEBUG
-#define M_KII_LOG(f_, ...) printf((f_), __VA_ARGS__)
+#define M_KII_DEBUG(f) f
 #else
-#define M_KII_LOG(f_, ...)
+#define M_KII_DEBUG(f)
 #endif
 
 #ifdef __cplusplus
 }
 #endif
+
+int prv_log(const char* format, ...);
 
 #endif /* defined(__KiiThingSDK__kii_logger__) */


### PR DESCRIPTION
#6 でM_KII_LOGの修正が残っていました。

M_KII_LOGは可変長マクロなのでC89で使えないのでM_KII_DEBUGを追加しました。

`M_KII_DEBUG(log("this is log: %s", "here is log"));` 

という形で利用します。これで可変長引数を使いつつ、リリース時にはコンパイルされない状況になりました。
