### PR TITLE
subscribing metnod returned KIIE_OK if bucket or topic is already subscribed

### DIFF
--- a/KiiThingSDK/kii_cloud.c
+++ b/KiiThingSDK/kii_cloud.c
@@ -1360,6 +1360,10 @@ kii_error_code_t kii_subscribe_bucket(kii_app_t app,
                            &respBodyStr,
                            NULL,
                            &error);
+    if (respStatus == 409) {
+        /* bucket is already subscribed. */
+        ret = KIIE_OK;
+    }
 
 ON_EXIT:
     M_KII_FREE_NULLIFY(url);
@@ -1630,6 +1634,10 @@ kii_error_code_t kii_subscribe_topic(kii_app_t app,
                      &respBodyStr,
                      NULL,
                      &error);
+    if (respStatus == 409) {
+        /* topic is already subscribed. */
+        ret = KIIE_OK;
+    }
 
 ON_EXIT:
     M_KII_FREE_NULLIFY(url);


### PR DESCRIPTION
登録済のbucketとtopicを再度登録しようとした場合にKIIE_OKが返るように修正しました。

関連issue #52 
